### PR TITLE
BS4 and BS5 classes for checkboxes and radios

### DIFF
--- a/views/checkboxes.php
+++ b/views/checkboxes.php
@@ -13,9 +13,9 @@
 		<?php foreach ($options['choices'] as $value => $label):
 			$id = "for-$name-$value";
 			?>
-			<div class="form-option">
-				<?php echo Form::checkbox($name . '[]', $value, in_array($value, (array) $options['selected']), ['id' => $id]); ?>
-				<?php echo Form::label($id, $label); ?>
+			<div class="form-check">
+				<?php echo Form::checkbox($name . '[]', $value, in_array($value, (array) $options['selected']), ['id' => $id, 'class' => 'form-check-input']); ?>
+				<?php echo Form::label($id, $label, ['class' => 'form-check-label']); ?>
 			</div>
 		<?php endforeach; ?>
 	</div>

--- a/views/radios.php
+++ b/views/radios.php
@@ -13,9 +13,9 @@
 		<?php foreach ($options['choices'] as $value => $label):
 			$id = "for-$name-$value";
 			?>
-			<div class="form-option">
-				<?php echo Form::radio($name, $value, !is_null($options['selected']) && $value == $options['selected'], ['id' => $id]); ?>
-				<?php echo Form::label($id, $label); ?>
+			<div class="form-check">
+				<?php echo Form::radio($name, $value, !is_null($options['selected']) && $value == $options['selected'], ['id' => $id, 'class' => 'form-check-input']); ?>
+				<?php echo Form::label($id, $label, ['class' => 'form-check-label']); ?>
 			</div>
 		<?php endforeach; ?>
 	</div>


### PR DESCRIPTION
Classes in form-builder-extras are for BS3. In BS4 and BS5 it changed. I changed both templates with the correct classes:

https://getbootstrap.com/docs/5.1/forms/checks-radios/
https://getbootstrap.com/docs/4.6/components/forms/#checkboxes-and-radios

Maybe not the correct way for templates, but I am not sure where to fix it elsewhere. 

